### PR TITLE
DS3231 - Add method to configure activation of INT/SQW pin on alarm, this allows MCU to be woken from power down (sleep) modes via an interrupt pin

### DIFF
--- a/docs/urtc.rst
+++ b/docs/urtc.rst
@@ -66,6 +66,12 @@ DS3231
         Get or set the value of the alarm flag. This is set to ``True`` when
         an alarm is triggered, and has to be cleared manually.
 
+    .. method:: interrupt(alarm=0)
+
+            Configure the INT/SQW pin to be activated when an alarm occurs.
+            The INT/SQW pin may be connect to an interrupt pin on the MCU to wake
+            it from a power down (sleep) mode.
+
     .. method:: stop(value=None)
 
         Get or set the status of the stop clock flag. This can be used to start

--- a/docs/urtc.rst
+++ b/docs/urtc.rst
@@ -68,9 +68,14 @@ DS3231
 
     .. method:: interrupt(alarm=0)
 
-            Configure the INT/SQW pin to be activated when an alarm occurs.
-            The INT/SQW pin may be connect to an interrupt pin on the MCU to wake
-            it from a power down (sleep) mode.
+        Configure the INT/SQW pin to be activated when an alarm occurs.
+        The INT/SQW pin may be connect to an interrupt pin on the MCU to wake
+        it from a power down (sleep) mode.
+
+    .. method:: no_interrupt()
+
+        Disable activation of the INT/SQW pin when an alarm occurs. This
+        disables both alarm 0 and alarm 1.
 
     .. method:: stop(value=None)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.core import setup
 setup(
     name='urtc',
     py_modules=['urtc'],
-    version="1.2",
+    version="1.3",
     description="Drivers for RTC modules for MicroPython.",
     long_description="""\
 This library lets you communicate with several real-time clock modules. At

--- a/urtc.py
+++ b/urtc.py
@@ -117,6 +117,10 @@ class DS3231(_BaseRTC):
         return self._flag(self._STATUS_REGISTER,
                           0b00000011 & (1 << alarm), value)
 
+    def interrupt(self, alarm=0):
+        return self._flag(self._CONTROL_REGISTER,
+                          0b00000100 | (1 << alarm), 1)
+
     def stop(self, value=None):
         return self._flag(self._CONTROL_REGISTER, 0b10000000, value)
 

--- a/urtc.py
+++ b/urtc.py
@@ -121,6 +121,9 @@ class DS3231(_BaseRTC):
         return self._flag(self._CONTROL_REGISTER,
                           0b00000100 | (1 << alarm), 1)
 
+    def no_interrupt(self):
+        return self._flag(self._CONTROL_REGISTER, 0b00000011, 0)
+
     def stop(self, value=None):
         return self._flag(self._CONTROL_REGISTER, 0b10000000, value)
 


### PR DESCRIPTION
The behavior enable by the PR is described on pages 11 to 14 of the [DS3231 Datasheet](https://datasheets.maximintegrated.com/en/ds/DS3231.pdf). Two new methods are provided:
* interrupt() - configures the INT/SQW pin to be activated for a specified alarm (0 or 1).
* no_interrupt() - unconfigures INT/SQW pin activation for both alarms.

The documentation is updated to describe these methods and the library version is increased from 1.2 to 1.3.