### PR TITLE
fixed alarm bug in DS3231 class

### DIFF
--- a/urtc.py
+++ b/urtc.py
@@ -165,9 +165,9 @@ class DS3231(_BaseRTC):
         if datetime.day is not None:
             if datetime.weekday is not None:
                 raise ValueError("can't specify both day and weekday")
-            buffer[2] = _bin2bcd(datetime.day) | 0b01000000
+            buffer[2] = _bin2bcd(datetime.day)
         elif datetime.weekday is not None:
-            buffer[2] = _bin2bcd(datetime.weekday)
+            buffer[2] = _bin2bcd(datetime.weekday) | 0b01000000
         else:
             buffer[2] = 0x80
         self._register(self._ALARM_REGISTERS[alarm], buffer)


### PR DESCRIPTION
I was having problems getting alarms to work for a DS3231 device
I debugged this module code and found that Bit 6 of the alarm day/date register is set incorrectly. According to the DS3231 datasheet, Bit 6 is set when day-of-the-week is used.